### PR TITLE
Facebook GraphAPIVersion 3.0

### DIFF
--- a/src/FacebookAuthController.php
+++ b/src/FacebookAuthController.php
@@ -43,7 +43,7 @@ class FacebookAuthController extends AbstractOAuth2Controller
             'clientId'        => $this->settings->get('flarum-auth-facebook.app_id'),
             'clientSecret'    => $this->settings->get('flarum-auth-facebook.app_secret'),
             'redirectUri'     => $redirectUri,
-            'graphApiVersion' => 'v2.8',
+            'graphApiVersion' => 'v3.0',
         ]);
     }
 


### PR DESCRIPTION
Facebook only provides graphApiVersion 3.0 for new apps. Therefore, it should also be adapted in the file. Otherwise you get a 500 error on your login/reg screen.